### PR TITLE
Add links to some alternative ways to use Embedded Mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Snapshots (Repository http://oss.sonatype.org/content/repositories/snapshots)
 		<version>1.18-SNAPSHOT</version>
 	</dependency>
 
+### Other ways to use Embedded MongoDB
+
+- In a Maven build using [embedmongo-maven-plugin](https://github.com/joelittlejohn/embedmongo-maven-plugin)
+- In a Clojure/Leiningen project using [lein-embongo](https://github.com/joelittlejohn/lein-embongo)
+- In a Scala/specs2 specification using [specs2-embedmongo](https://github.com/athieriot/specs2-embedmongo)
+
 ### Changelog
 
 #### 1.18 (SNAPSHOT)


### PR DESCRIPTION
Added a list of plugins that make it easier to integrate the Embedded Mongo API when using various build and test tools. I think this is a very useful list for newcomers.

Disclaimer: I created two of these.

Cheers!
