### PR TITLE
Gradle build has old version of de.flapdoodle.embed.process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ velocity.log
 .settings
 .externalToolBuilders
 .idea
+.gradle
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testCompile 'org.mortbay.jetty:jetty:6.1.25'
     
     compile 'commons-io:commons-io:2.1'
-    compile 'de.flapdoodle.embed:de.flapdoodle.embed.process:1.23'
+    compile 'de.flapdoodle.embed:de.flapdoodle.embed.process:1.27'
     compile 'org.mongodb:mongo-java-driver:2.9.0'
 }
 


### PR DESCRIPTION
...s. Bump to 1.27 inline with pom.xml
