### PR TITLE
Adding link to Gradle Mongo Plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Embedded MongoDB will provide a platform neutral way for running mongodb in unit
 
 - in a Maven build using [embedmongo-maven-plugin](https://github.com/joelittlejohn/embedmongo-maven-plugin)
 - in a Clojure/Leiningen project using [lein-embongo](https://github.com/joelittlejohn/lein-embongo)
+- in a Gradle build using [gradle-mongo-plugin](https://github.com/sourcemuse/GradleMongoPlugin)
 - in a Scala/specs2 specification using [specs2-embedmongo](https://github.com/athieriot/specs2-embedmongo)
 - in Scala tests using [scalatest-embedmongo](https://github.com/SimplyScala/scalatest-embedmongo)
 


### PR DESCRIPTION
Hi, nice tool! We've started using it in the [Gradle Mongo Plugin](https://github.com/sourcemuse/GradleMongoPlugin).
