### PR TITLE
fix wrong variable name in the Usage part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Support for Linux, Windows and MacOSX.
 
 	MongodExecutable mongodExecutable = null;
 	try {
-		mongodExecutable = starter.prepare(mongodConfig);
+		mongodExecutable = runtime.prepare(mongodConfig);
 		MongodProcess mongod = mongodExecutable.start();
 
 		MongoClient mongo = new MongoClient("localhost", port);


### PR DESCRIPTION
```
MongodStarter runtime = MongodStarter.getDefaultInstance();
```

later on 

```
mongodExecutable = starter.prepare(mongodConfig);
```

instead of

```
mongodExecutable = runtime.prepare(mongodConfig);
```

is used
