### PR TITLE
FreeBSD (OS) support

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/Paths.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/Paths.java
@@ -20,18 +20,12 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-
-import de.flapdoodle.embed.process.distribution.ArchiveType;
-import de.flapdoodle.embed.process.distribution.BitSize;
-import de.flapdoodle.embed.process.distribution.Distribution;
-import de.flapdoodle.embed.process.distribution.IVersion;
-import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.process.config.store.FileSet;
 import de.flapdoodle.embed.process.config.store.FileType;
-import de.flapdoodle.embed.process.config.store.IDownloadConfig;
 import de.flapdoodle.embed.process.config.store.IPackageResolver;
+import de.flapdoodle.embed.process.distribution.*;
+
+import java.util.logging.Logger;
 
 /**
  *
@@ -52,6 +46,7 @@ public class Paths implements IPackageResolver {
 			case Linux:
 			case OS_X:
 			case Solaris:
+			case FreeBSD:
 				executableFileName = command.commandName();
 				break;
 			case Windows:
@@ -69,14 +64,13 @@ public class Paths implements IPackageResolver {
 		ArchiveType archiveType;
 		switch (distribution.getPlatform()) {
 			case Linux:
+			case OS_X:
 			case Solaris:
+			case FreeBSD:
 				archiveType = ArchiveType.TGZ;
 				break;
 			case Windows:
 				archiveType = ArchiveType.ZIP;
-				break;
-			case OS_X:
-				archiveType = ArchiveType.TGZ;
 				break;
 			default:
 				throw new IllegalArgumentException("Unknown Platform " + distribution.getPlatform());
@@ -114,6 +108,9 @@ public class Paths implements IPackageResolver {
 				break;
 			case Solaris:
 				splatform = "sunos5";
+				break;
+			case FreeBSD:
+				splatform = "freebsd";
 				break;
 			default:
 				throw new IllegalArgumentException("Unknown Platform " + distribution.getPlatform());

--- a/src/test/java/de/flapdoodle/embed/mongo/MongoDBRuntimeTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/MongoDBRuntimeTest.java
@@ -20,24 +20,11 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import junit.framework.TestCase;
-
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.Mongo;
-
-import de.flapdoodle.embed.mongo.config.ArtifactStoreBuilder;
-import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
+import de.flapdoodle.embed.mongo.config.*;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.distribution.BitSize;
@@ -46,6 +33,12 @@ import de.flapdoodle.embed.process.distribution.IVersion;
 import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.runtime.Network;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 // CHECKSTYLE:OFF
 public class MongoDBRuntimeTest extends TestCase {
@@ -97,13 +90,16 @@ public class MongoDBRuntimeTest extends TestCase {
 
 	private boolean shipThisVersion(Platform platform, IVersion version, BitSize bitsize) {
 		String currentVersion = version.asInDownloadPath();
-    if ((platform == Platform.OS_X) && (bitsize == BitSize.B32)) {
-  		// there is no osx 32bit version for v2.2.1 and above, so we dont check
-    	return true;
-    }
-    if ((platform == Platform.Solaris)  && (bitsize == BitSize.B32)) {
-    	return true;
-    }
+		if ((platform == Platform.OS_X) && (bitsize == BitSize.B32)) {
+			// there is no osx 32bit version for v2.2.1 and above, so we dont check
+			return true;
+		}
+		if ((platform == Platform.Solaris)  && (bitsize == BitSize.B32)) {
+			return true;
+		}
+		if ((platform == Platform.FreeBSD)  && (bitsize == BitSize.B32)) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
FreeBSD is now supported. However, you will have to provide a FreeBSD distribution of MongoDB yourself, because there's no official distribution available to download from MongoDB site.
