### PR TITLE
Implement equals and hashCode on GenericFeatureAwareVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'de.flapdoodle.embed:de.flapdoodle.embed.process:1.40.0'
     compile 'org.mongodb:mongo-java-driver:2.11.3'
 
-    testCompile 'junit:junit:4.10'
+    testCompile 'junit:junit:4.11'
     testCompile 'org.mongodb:mongo-java-driver:2.6.3'
     testCompile 'org.mockito:mockito-core:1.9.0'
     testCompile 'org.mortbay.jetty:jetty:6.1.25'

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/de/flapdoodle/embed/mongo/distribution/Versions.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/distribution/Versions.java
@@ -24,8 +24,8 @@ import java.util.EnumSet;
 
 import de.flapdoodle.embed.process.distribution.IVersion;
 
-
 public class Versions {
+
 	private Versions() {
 		// no instance
 	}
@@ -53,6 +53,38 @@ public class Versions {
 		public boolean enabled(Feature feature) {
 			return _features.contains(feature);
 		}
-		
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result
+					+ ((_features == null) ? 0 : _features.hashCode());
+			result = prime * result + ((_version == null) ? 0 : _version.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			GenericFeatureAwareVersion other = (GenericFeatureAwareVersion) obj;
+			if (_features == null) {
+				if (other._features != null)
+					return false;
+			} else if (!_features.equals(other._features))
+				return false;
+			if (_version == null) {
+				if (other._version != null)
+					return false;
+			} else if (!_version.equals(other._version))
+				return false;
+			return true;
+		}
+
 	}
 }

--- a/src/test/java/de/flapdoodle/embed/mongo/distribution/VersionsTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/distribution/VersionsTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2011
+ *   Michael Mosmann <michael@mosmann.de>
+ *   Martin Jöhren <m.joehren@googlemail.com>
+ *
+ * with contributions from
+ *      konstantin-ba@github,Archimedes Trajano (trajano@github)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.flapdoodle.embed.mongo.distribution;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import de.flapdoodle.embed.process.distribution.GenericVersion;
+
+public class VersionsTest {
+
+	@Test
+	public void testEquals() {
+		assertEquals(Versions.withFeatures(new GenericVersion("2.6.5")), Versions.withFeatures(new GenericVersion("2.6.5")));
+		assertEquals(Versions.withFeatures(new GenericVersion("2.6.5"), Feature.TEXT_SEARCH), Versions.withFeatures(new GenericVersion("2.6.5"), Feature.TEXT_SEARCH));
+		assertNotEquals(Versions.withFeatures(new GenericVersion("2.6.5")), Versions.withFeatures(new GenericVersion("2.6.5"), Feature.TEXT_SEARCH));
+	}
+
+}


### PR DESCRIPTION
Implement equals and hashCode on GenericFeatureAwareVersion so that CachingArtifactStore can work. Version is a component of Distribution, which is used as the cache key of CachingArtifactStore
