### PR TITLE
Doc bug in readme: typo in the quotes of the Gradle dependency definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Snapshots (Repository http://oss.sonatype.org/content/repositories/snapshots)
 Make sure you have mavenCentral() in your repositories or that your enterprise/local server prixies the maven central repository.
 
 	dependencies {
-		testCompile group: "de.flapdoodle.embed", name: "de.flapdoodle.embed.mongo", "version: 1.46.4"
+		testCompile group: "de.flapdoodle.embed", name: "de.flapdoodle.embed.mongo", version: "1.46.4"
 	}
 
 ### Build from source


### PR DESCRIPTION
Incorrect: "version: 1.46.4"
Correct: version: "1.46.4"