### PR TITLE
Replace java.util.logging with Slf4j facade (fixes #67)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,14 @@ dependencies {
     compile 'commons-io:commons-io:2.1'
     compile 'de.flapdoodle.embed:de.flapdoodle.embed.process:1.40.1'
     compile 'org.mongodb:mongo-java-driver:2.11.3'
+    compile 'org.slf4j:slf4j-api:1.7.10'
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.mongodb:mongo-java-driver:2.6.3'
     testCompile 'org.mockito:mockito-core:1.9.0'
     testCompile 'org.mortbay.jetty:jetty:6.1.25'
     testCompile 'com.google.guava:guava:14.0.1'
+    testCompile 'org.slf4j:slf4j-simple:1.7.10'
 }
 
 task wrapper(type: Wrapper) {

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,8 @@
 			de.flapdoodle.embed.process.io.progress,
 			de.flapdoodle.embed.process.runtime,
 			de.flapdoodle.embed.process.store,
-			org.apache.commons.io
+			org.apache.commons.io,
+			org.slf4j
 		</osgi.import>
 	</properties>
 	
@@ -299,7 +300,13 @@
 		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.process</artifactId>
-			<version>1.40.1</version>
+			<version>1.40.2-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.10</version>
 		</dependency>
 
 		<dependency>
@@ -326,6 +333,13 @@
 			<groupId>org.mortbay.jetty</groupId>
 			<artifactId>jetty</artifactId>
 			<version>6.1.25</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.mongo.config.IMongoConfig;
 import de.flapdoodle.embed.mongo.runtime.Mongod;
@@ -43,7 +43,7 @@ import de.flapdoodle.embed.process.runtime.ProcessControl;
 
 public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Executable<T, P>, P extends IStopable> extends AbstractProcess<T, E, P> {
 
-	private static Logger logger = Logger.getLogger(AbstractMongoProcess.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(AbstractMongoProcess.class);
 	
 	boolean stopped=false;
 	
@@ -95,13 +95,13 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 
 				stopped = true;
 
-				logger.fine("try to stop mongod");
+				logger.debug("try to stop mongod");
 				if (!sendStopToMongoInstance()) {
-					logger.warning("could not stop mongod with db command, try next");
+					logger.warn("could not stop mongod with db command, try next");
 					if (!sendKillToProcess()) {
-						logger.warning("could not stop mongod, try next");
+						logger.warn("could not stop mongod, try next");
 						if (!tryKillToProcess()) {
-							logger.warning("could not stop mongod the second time, try one last thing");
+							logger.warn("could not stop mongod the second time, try one last thing");
 						}
 					}
 				}
@@ -124,7 +124,7 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 		try {
 			return Mongod.sendShutdown(getConfig().net().getServerAddress(), getConfig().net().getPort());
 		} catch (UnknownHostException e) {
-			logger.log(Level.SEVERE, "sendStop", e);
+			logger.error("sendStop", e);
 		}
 		return false;
 	}

--- a/src/main/java/de/flapdoodle/embed/mongo/MongoImportExecutable.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongoImportExecutable.java
@@ -29,7 +29,6 @@ import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.runtime.Executable;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 /**
  * Created by canyaman on 10/04/14.
@@ -39,8 +38,6 @@ public class MongoImportExecutable extends Executable<IMongoImportConfig, MongoI
                             IExtractedFileSet files) {
         super(distribution, mongodConfig, runtimeConfig, files);
     }
-
-    private static Logger logger = Logger.getLogger(MongosExecutable.class.getName());
 
     @Override
     protected MongoImportProcess start(Distribution distribution, IMongoImportConfig config, IRuntimeConfig runtime)

--- a/src/main/java/de/flapdoodle/embed/mongo/MongoImportStarter.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongoImportStarter.java
@@ -29,14 +29,10 @@ import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 import de.flapdoodle.embed.process.runtime.Starter;
 
-import java.util.logging.Logger;
-
 /**
  * Created by canyaman on 10/04/14.
  */
 public class MongoImportStarter extends Starter<IMongoImportConfig,MongoImportExecutable,MongoImportProcess> {
-
-    private static Logger logger = Logger.getLogger(MongosStarter.class.getName());
 
     private MongoImportStarter(IRuntimeConfig config) {
         super(config);

--- a/src/main/java/de/flapdoodle/embed/mongo/MongoShellProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongoShellProcess.java
@@ -22,7 +22,6 @@ package de.flapdoodle.embed.mongo;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 
 import de.flapdoodle.embed.mongo.config.IMongoShellConfig;
 import de.flapdoodle.embed.mongo.config.SupportConfig;

--- a/src/main/java/de/flapdoodle/embed/mongo/MongoShellStarter.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongoShellStarter.java
@@ -20,8 +20,6 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.util.logging.Logger;
-
 import de.flapdoodle.embed.mongo.config.IMongoShellConfig;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -33,8 +31,6 @@ import de.flapdoodle.embed.process.runtime.Starter;
  *
  */
 public class MongoShellStarter extends Starter<IMongoShellConfig, MongoShellExecutable ,MongoShellProcess> {
-
-	private static Logger logger = Logger.getLogger(MongoShellStarter.class.getName());
 
 	private MongoShellStarter(IRuntimeConfig config) {
 		super(config);

--- a/src/main/java/de/flapdoodle/embed/mongo/MongodProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongodProcess.java
@@ -23,7 +23,8 @@ package de.flapdoodle.embed.mongo;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.SupportConfig;
@@ -40,7 +41,7 @@ import de.flapdoodle.embed.process.io.file.Files;
  */
 public class MongodProcess extends AbstractMongoProcess<IMongodConfig, MongodExecutable, MongodProcess> {
 
-	private static Logger logger = Logger.getLogger(MongodProcess.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(MongodProcess.class);
 
 	private File dbDir;
 	boolean dbDirIsTemp;
@@ -90,7 +91,7 @@ public class MongodProcess extends AbstractMongoProcess<IMongodConfig, MongodExe
 		super.deleteTempFiles();
 		
 		if ((dbDir != null) && (dbDirIsTemp) && (!Files.forceDelete(dbDir))) {
-			logger.warning("Could not delete temp db dir: " + dbDir);
+			logger.warn("Could not delete temp db dir: {}", dbDir);
 		}
 		
 	}

--- a/src/main/java/de/flapdoodle/embed/mongo/MongodStarter.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongodStarter.java
@@ -20,10 +20,6 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.config.SupportConfig;
@@ -38,8 +34,6 @@ import de.flapdoodle.embed.process.runtime.Starter;
  *
  */
 public class MongodStarter extends Starter<IMongodConfig,MongodExecutable,MongodProcess> {
-
-	private static Logger logger = Logger.getLogger(MongodStarter.class.getName());
 
 	private MongodStarter(IRuntimeConfig config) {
 		super(config);

--- a/src/main/java/de/flapdoodle/embed/mongo/MongosExecutable.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongosExecutable.java
@@ -20,9 +20,7 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import de.flapdoodle.embed.mongo.config.IMongosConfig;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -39,8 +37,6 @@ public class MongosExecutable extends Executable<IMongosConfig, MongosProcess> {
 			IExtractedFileSet files) {
 		super(distribution, mongodConfig, runtimeConfig, files);
 	}
-
-	private static Logger logger = Logger.getLogger(MongosExecutable.class.getName());
 
 	@Override
 	protected MongosProcess start(Distribution distribution, IMongosConfig config, IRuntimeConfig runtime)

--- a/src/main/java/de/flapdoodle/embed/mongo/MongosStarter.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongosStarter.java
@@ -20,9 +20,6 @@
  */
 package de.flapdoodle.embed.mongo;
 
-import java.io.File;
-import java.util.logging.Logger;
-
 import de.flapdoodle.embed.mongo.config.IMongosConfig;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
@@ -34,8 +31,6 @@ import de.flapdoodle.embed.process.runtime.Starter;
  *
  */
 public class MongosStarter extends Starter<IMongosConfig,MongosExecutable,MongosProcess> {
-
-	private static Logger logger = Logger.getLogger(MongosStarter.class.getName());
 
 	private MongosStarter(IRuntimeConfig config) {
 		super(config);

--- a/src/main/java/de/flapdoodle/embed/mongo/Paths.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/Paths.java
@@ -25,14 +25,11 @@ import de.flapdoodle.embed.process.config.store.FileType;
 import de.flapdoodle.embed.process.config.store.IPackageResolver;
 import de.flapdoodle.embed.process.distribution.*;
 
-import java.util.logging.Logger;
-
 /**
  *
  */
 public class Paths implements IPackageResolver {
 
-	private static Logger logger = Logger.getLogger(Paths.class.getName());
 	private final Command command;
 
 	public Paths(Command command) {

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongodProcessOutputConfig.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongodProcessOutputConfig.java
@@ -20,8 +20,6 @@
  */
 package de.flapdoodle.embed.mongo.config;
 
-import java.util.logging.Logger;
-
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
 
@@ -34,7 +32,12 @@ public class MongodProcessOutputConfig {
 		return ProcessOutput.getDefaultInstance(command.commandName());
 	}
 
-	public static ProcessOutput getInstance(Command command, Logger logger) {
+	@Deprecated
+	public static ProcessOutput getInstance(Command command, java.util.logging.Logger logger) {
+		return ProcessOutput.getInstance(command.commandName(), logger);
+	}
+
+	public static ProcessOutput getInstance(Command command, org.slf4j.Logger logger) {
 		return ProcessOutput.getInstance(command.commandName(), logger);
 	}
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/RuntimeConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/RuntimeConfigBuilder.java
@@ -20,24 +20,39 @@
  */
 package de.flapdoodle.embed.mongo.config;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
+import de.flapdoodle.embed.process.io.progress.Slf4jProgressListener;
 
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.process.config.store.IDownloadConfig;
-import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
 import de.flapdoodle.embed.process.runtime.ICommandLinePostProcessor;
+
+import java.util.logging.Level;
 
 
 public class RuntimeConfigBuilder extends de.flapdoodle.embed.process.config.RuntimeConfigBuilder {
 
-	public RuntimeConfigBuilder defaultsWithLogger(Command command, Logger logger) {
+	@Deprecated
+	public RuntimeConfigBuilder defaultsWithLogger(Command command, java.util.logging.Logger logger) {
 		defaults(command);
 		processOutput().overwriteDefault(MongodProcessOutputConfig.getInstance(command, logger));
 
 		IDownloadConfig downloadConfig = new DownloadConfigBuilder()
 				.defaultsForCommand(command)
 				.progressListener(new LoggingProgressListener(logger, Level.FINE))
+				.build();
+
+		artifactStore().overwriteDefault(new ArtifactStoreBuilder().defaults(command).download(downloadConfig).build());
+		return this;
+	}
+
+	public RuntimeConfigBuilder defaultsWithLogger(Command command, org.slf4j.Logger logger) {
+		defaults(command);
+		processOutput().overwriteDefault(MongodProcessOutputConfig.getInstance(command, logger));
+
+		IDownloadConfig downloadConfig = new DownloadConfigBuilder()
+				.defaultsForCommand(command)
+				.progressListener(new Slf4jProgressListener(logger))
 				.build();
 
 		artifactStore().overwriteDefault(new ArtifactStoreBuilder().defaults(command).download(downloadConfig).build());

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoImport.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoImport.java
@@ -28,14 +28,11 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * Created by canyaman on 10/04/14.
  */
 public class MongoImport extends AbstractMongo {
-
-    private static Logger logger = Logger.getLogger(Mongos.class.getName());
 
     public static List<String> getCommandLine(IMongoImportConfig config, IExtractedFileSet files)
             throws UnknownHostException {

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoShell.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoShell.java
@@ -24,7 +24,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 
 import de.flapdoodle.embed.mongo.config.IMongoShellConfig;
 import de.flapdoodle.embed.mongo.config.Net;

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
@@ -40,8 +40,8 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
  */
 public class Mongod extends AbstractMongo {
 
-	private static Logger logger = Logger.getLogger(Mongod.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(Mongod.class);
 
 	/**
 	 * Binary sample of shutdown command
@@ -67,11 +67,10 @@ public class Mongod extends AbstractMongo {
 
 	public static boolean sendShutdown(InetAddress hostname, int port) {
 		if (!hostname.isLoopbackAddress()) {
-			logger.log(Level.WARNING,
-					"" + "---------------------------------------\n" + "Your localhost (" + hostname.getHostAddress()
-							+ ") is not a loopback adress\n"
-							+ "We can NOT send shutdown to mongod, because it is denied from remote."
-							+ "---------------------------------------\n");
+			logger.warn("---------------------------------------\n"
+                    + "Your localhost ({}) is not a loopback adress\n"
+                    + "We can NOT send shutdown to mongod, because it is denied from remote.\n"
+                    + "---------------------------------------\n", hostname.getHostAddress());
 			return false;
 		}
 
@@ -88,7 +87,7 @@ public class Mongod extends AbstractMongo {
 			tryToReadErrorResponse = true;
 			InputStream inputStream = s.getInputStream();
 			if (inputStream.read(new byte[BYTE_BUFFER_LENGTH]) != -1) {
-				logger.severe("Got some response, should be an error message");
+				logger.error("Got some response, should be an error message");
 				return false;
 			}
 			return true;
@@ -96,15 +95,15 @@ public class Mongod extends AbstractMongo {
 			if (tryToReadErrorResponse) {
 				return true;
 			}
-			logger.log(Level.WARNING, String.format("sendShutdown %s:%d", hostname, port), iox);
+			logger.warn("sendShutdown {}:{}", hostname, port, iox);
 		} finally {
 			try {
 				s.close();
 				Thread.sleep(WAITING_TIME_SHUTDOWN_IN_MS);
 			} catch (InterruptedException ix) {
-				logger.log(Level.WARNING, String.format("sendShutdown closing %s:%d", hostname, port), ix);
+				logger.warn("sendShutdown closing {}:{}", hostname, port, ix);
 			} catch (IOException iox) {
-				logger.log(Level.WARNING, String.format("sendShutdown closing %s:%s", hostname, port), iox);
+				logger.warn("sendShutdown closing {}:{}", hostname, port, iox);
 			}
 		}
 		return false;
@@ -189,8 +188,8 @@ public class Mongod extends AbstractMongo {
 					ret.add("--interleave=all");
 					ret.addAll(commands);
 					return ret;
-				default:
-					logger.warning("NUMA Plattform detected, but not supported.");
+                default:
+                    logger.warn("NUMA Plattform detected, but not supported.");
 			}
 		}
 		return commands;

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongos.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongos.java
@@ -24,7 +24,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 
 import de.flapdoodle.embed.mongo.config.IMongosConfig;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
@@ -33,8 +32,6 @@ import de.flapdoodle.embed.process.extract.IExtractedFileSet;
  *
  */
 public class Mongos extends AbstractMongo {
-
-	private static Logger logger = Logger.getLogger(Mongos.class.getName());
 
 	public static List<String> getCommandLine(IMongosConfig config, IExtractedFileSet files)
 			throws UnknownHostException {

--- a/src/main/java/de/flapdoodle/embed/mongo/tests/MongodForTestsFactory.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/tests/MongodForTestsFactory.java
@@ -23,7 +23,8 @@ package de.flapdoodle.embed.mongo.tests;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.UUID;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
@@ -47,7 +48,7 @@ import de.flapdoodle.embed.mongo.distribution.Version;
  */
 public class MongodForTestsFactory {
 
-	private static Logger logger = Logger.getLogger(MongodForTestsFactory.class
+	private static Logger logger = LoggerFactory.getLogger(MongodForTestsFactory.class
 			.getName());
 
 	public static MongodForTestsFactory with(final IFeatureAwareVersion version)

--- a/src/main/java/de/flapdoodle/embed/mongo/tests/MongosForTestsFactory.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/tests/MongosForTestsFactory.java
@@ -23,7 +23,8 @@ package de.flapdoodle.embed.mongo.tests;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.UUID;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
@@ -49,7 +50,7 @@ import de.flapdoodle.embed.process.runtime.Network;
  */
 public class MongosForTestsFactory {
 
-	private static Logger logger = Logger.getLogger(MongosForTestsFactory.class
+	private static Logger logger = LoggerFactory.getLogger(MongosForTestsFactory.class
 			.getName());
 
 	public static MongosForTestsFactory with(final IFeatureAwareVersion version)

--- a/src/main/java/de/flapdoodle/embed/mongo/tests/MongosSystemForTestFactory.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/tests/MongosSystemForTestFactory.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -53,8 +54,8 @@ import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 
 public class MongosSystemForTestFactory {
 
-	private final static Logger logger = Logger
-			.getLogger(MongosSystemForTestFactory.class.getName());
+	private final static Logger logger = LoggerFactory
+			.getLogger(MongosSystemForTestFactory.class);
 
 	public static final String ADMIN_DATABASE_NAME = "admin";
 	public static final String LOCAL_DATABASE_NAME = "local";
@@ -129,7 +130,7 @@ public class MongosSystemForTestFactory {
 
 		CommandResult cr = mongoAdminDB
 				.command(new BasicDBObject("isMaster", 1));
-		logger.info("isMaster: " + cr);
+		logger.info("isMaster: {}", cr);
 
 		// Build BSON object replica set settings
 		DBObject replicaSetSetting = new BasicDBObject();
@@ -149,18 +150,18 @@ public class MongosSystemForTestFactory {
 		// Initialize replica set
 		cr = mongoAdminDB.command(new BasicDBObject("replSetInitiate",
 				replicaSetSetting));
-		logger.info("replSetInitiate: " + cr);
+		logger.info("replSetInitiate: {}", cr);
 
 		Thread.sleep(5000);
 		cr = mongoAdminDB.command(new BasicDBObject("replSetGetStatus", 1));
-		logger.info("replSetGetStatus: " + cr);
+		logger.info("replSetGetStatus: {}", cr);
 
 		// Check replica set status before to proceed
 		while (!isReplicaSetStarted(cr)) {
 			logger.info("Waiting for 3 seconds...");
 			Thread.sleep(1000);
 			cr = mongoAdminDB.command(new BasicDBObject("replSetGetStatus", 1));
-			logger.info("replSetGetStatus: " + cr);
+			logger.info("replSetGetStatus: {}", cr);
 		}
 
 		mongo.close();
@@ -177,7 +178,7 @@ public class MongosSystemForTestFactory {
 			BasicDBObject member = (BasicDBObject) m;
 			logger.info(member.toString());
 			int state = member.getInt("state");
-			logger.info("state: " + state);
+			logger.info("state: {}", state);
 			// 1 - PRIMARY, 2 - SECONDARY, 7 - ARBITER
 			if (state != 1 && state != 2 && state != 7) {
 				return false;
@@ -229,7 +230,7 @@ public class MongosSystemForTestFactory {
 				command += mongodConfig.net().getServerAddress().getHostName()
 						+ ":" + mongodConfig.net().getPort();
 			}
-			logger.info("Execute add shard command: " + command);
+			logger.info("Execute add shard command: {}", command);
 			cr = mongoAdminDB.command(new BasicDBObject("addShard", command));
 			logger.info(cr.toString());
 		}
@@ -250,8 +251,7 @@ public class MongosSystemForTestFactory {
 		db.getCollection(this.shardCollection).ensureIndex(this.shardKey);
 
 		// Shard the collection
-		logger.info("Shard the collection: " + this.shardDatabase + "."
-				+ this.shardCollection);
+		logger.info("Shard the collection: {}.{}", this.shardDatabase, this.shardCollection);
 		DBObject cmd = new BasicDBObject();
 		cmd.put("shardCollection", this.shardDatabase + "." + this.shardCollection);
 		cmd.put("key", new BasicDBObject(this.shardKey, 1));

--- a/src/test/java/de/flapdoodle/embed/mongo/MongoExecutableTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/MongoExecutableTest.java
@@ -22,7 +22,8 @@ package de.flapdoodle.embed.mongo;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
@@ -52,7 +53,7 @@ import de.flapdoodle.embed.process.runtime.Network;
 //CHECKSTYLE:OFF
 public class MongoExecutableTest extends TestCase {
 
-	private static final Logger _logger = Logger.getLogger(MongoExecutableTest.class.getName());
+	private static final Logger _logger = LoggerFactory.getLogger(MongoExecutableTest.class.getName());
 
 	@Test
 	public void testStartStopTenTimesWithNewMongoExecutable() throws IOException {
@@ -64,7 +65,7 @@ public class MongoExecutableTest extends TestCase {
 		IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(Command.MongoD).build();
 
 		for (int i = 0; i < loops; i++) {
-			_logger.info("Loop: " + i);
+			_logger.info("Loop: {}", i);
 			MongodExecutable mongodExe = MongodStarter.getInstance(runtimeConfig).prepare(mongodConfig);
 			try {
 				MongodProcess mongod = mongodExe.start();

--- a/src/test/java/de/flapdoodle/embed/mongo/MongoImportExecutableTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/MongoImportExecutableTest.java
@@ -34,14 +34,15 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Date;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by canyaman on 10/04/14.
  */
 public class MongoImportExecutableTest  extends TestCase {
 
-    private static final Logger _logger = Logger.getLogger(MongoImportExecutableTest.class.getName());
+    private static final Logger _logger = LoggerFactory.getLogger(MongoImportExecutableTest.class.getName());
 
     @Test
     public void testStartMongoImport() throws IOException, InterruptedException {
@@ -63,7 +64,7 @@ public class MongoImportExecutableTest  extends TestCase {
             mongoImportProcess=mongoImportExecutable.start();
             dataImported=true;
         }catch (Exception e){
-            _logger.info("MongoImport exception:" + e.getStackTrace());
+            _logger.info("MongoImport exception: {}", e.getStackTrace());
             dataImported=false;
         }finally {
            Assert.assertTrue("mongoDB import data in json format", dataImported);

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=trace


### PR DESCRIPTION
I’ve modified it with API backward compatibility in mind, so it shouldn’t break existing code that depends on it.

Depends on https://github.com/flapdoodle-oss/de.flapdoodle.embed.process/pull/22.