### PR TITLE
Fixes #114 - Enable auth issue

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/config/IMongoCmdOptions.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/IMongoCmdOptions.java
@@ -34,4 +34,6 @@ public interface IMongoCmdOptions {
 	boolean useNoJournal();
 	
 	boolean enableTextSearch();
+
+    boolean enableAuth();
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
@@ -31,7 +31,8 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 	protected static final TypedProperty<Boolean> NOPREALLOC = TypedProperty.with("noprealloc", Boolean.class);
 	protected static final TypedProperty<Boolean> SMALLFILES = TypedProperty.with("smallfiles", Boolean.class);
 	protected static final TypedProperty<Boolean> NOJOURNAL = TypedProperty.with("nojournal", Boolean.class);
-	protected static final TypedProperty<Boolean> ENABLE_TEXTSEARCH = TypedProperty.with("enableTextSearch", Boolean.class);
+    protected static final TypedProperty<Boolean> ENABLE_TEXTSEARCH = TypedProperty.with("enableTextSearch", Boolean.class);
+    protected static final TypedProperty<Boolean> ENABLE_AUTH = TypedProperty.with("enableAuth", Boolean.class);
 	
 	
 	public MongoCmdOptionsBuilder() {
@@ -41,6 +42,7 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		property(SMALLFILES).setDefault(true);
 		property(NOJOURNAL).setDefault(true);
 		property(ENABLE_TEXTSEARCH).setDefault(false);
+        property(ENABLE_AUTH).setDefault(true);
 	}
 
 	public MongoCmdOptionsBuilder useNoPrealloc(boolean value) {
@@ -68,8 +70,8 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		return this;
 	}
 
-	public MongoCmdOptionsBuilder enableTextSearch(boolean verbose) {
-		set(ENABLE_TEXTSEARCH, verbose);
+	public MongoCmdOptionsBuilder enableTextSearch(boolean value) {
+		set(ENABLE_TEXTSEARCH, value);
 		return this;
 	}
 	
@@ -78,6 +80,11 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		return this;
 	}
 
+    public MongoCmdOptionsBuilder enableAuth(boolean verbose) {
+        set(ENABLE_AUTH, verbose);
+        return this;
+    }
+
 	@Override
 	public IMongoCmdOptions build() {
 		Integer syncDelay = get(SYNC_DELAY, null);
@@ -85,8 +92,9 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		boolean noPrealloc = get(NOPREALLOC);
 		boolean smallFiles = get(SMALLFILES);
 		boolean noJournal = get(NOJOURNAL);
-		boolean enableTextSearch = get(ENABLE_TEXTSEARCH);
-		return new MongoCmdOptions(syncDelay, verbose, noPrealloc, smallFiles, noJournal, enableTextSearch);
+        boolean enableTextSearch = get(ENABLE_TEXTSEARCH);
+        boolean enableAuth = get(ENABLE_AUTH);
+		return new MongoCmdOptions(syncDelay, verbose, noPrealloc, smallFiles, noJournal, enableTextSearch, enableAuth);
 	}
 
 	static class MongoCmdOptions implements IMongoCmdOptions {
@@ -97,16 +105,18 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		private final boolean _smallFiles;
 		private final boolean _noJournal;
 		private final boolean _enableTextSearch;
+        private final boolean _enableAuth;
 
 
 		public MongoCmdOptions(Integer syncDelay, boolean verbose, boolean noPrealloc, boolean smallFiles,
-		                       boolean noJournal, boolean enableTextSearch) {
+		                       boolean noJournal, boolean enableTextSearch, boolean enableAuth) {
 			_syncDelay = syncDelay;
 			_verbose = verbose;
 			_noPrealloc = noPrealloc;
 			_smallFiles = smallFiles;
 			_noJournal = noJournal;
 			_enableTextSearch = enableTextSearch;
+            _enableAuth = enableAuth;
 		}
 
 		@Override
@@ -138,5 +148,11 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		public boolean enableTextSearch() {
 			return _enableTextSearch;
 		}
-	}
+
+        @Override
+        public boolean enableAuth() {
+            return _enableAuth;
+        }
+
+    }
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
@@ -42,7 +42,7 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		property(SMALLFILES).setDefault(true);
 		property(NOJOURNAL).setDefault(true);
 		property(ENABLE_TEXTSEARCH).setDefault(false);
-        property(ENABLE_AUTH).setDefault(true);
+        property(ENABLE_AUTH).setDefault(false);
 	}
 
 	public MongoCmdOptionsBuilder useNoPrealloc(boolean value) {

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
@@ -126,7 +126,7 @@ public class Mongod extends AbstractMongo {
 				"--dbpath",
 				"" + dbDir.getAbsolutePath()));
 
-        if(config.cmdOptions().enableAuth()){
+        if(!config.cmdOptions().enableAuth()){
             ret.add("--noauth");
         }
 

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java
@@ -124,8 +124,11 @@ public class Mongod extends AbstractMongo {
 		List<String> ret = new ArrayList<String>();
 		ret.addAll(Arrays.asList(files.executable().getAbsolutePath(),
 				"--dbpath",
-				"" + dbDir.getAbsolutePath(),
-				"--noauth"));
+				"" + dbDir.getAbsolutePath()));
+
+        if(config.cmdOptions().enableAuth()){
+            ret.add("--noauth");
+        }
 
 		if (config.cmdOptions().useNoPrealloc()) {
 			ret.add("--noprealloc");


### PR DESCRIPTION
Added a new option IMongoCmdOptions and on its implementation and builder to have a new option that the user can set so the authentication of MongoDB will work. Changed Mongod to handle this feature. I didn't find any specific test for the options and I thought it would be harder to understand the test structure of the project so I didn't include a test with this PR unfortunately (by the way it took a lot of time to run the test in my machine and some fail and I created this branch from master) . More information about the issue on https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/114#issuecomment-78138302