### PR TITLE
Additional options for mongo.

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
@@ -51,7 +51,7 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 			throws IOException {
 		super(distribution, config, runtimeConfig, executable);
 	}
-	
+
 	@Override
 	protected final void onAfterProcessStart(ProcessControl process, IRuntimeConfig runtimeConfig) throws IOException {
 		ProcessOutput outputConfig = runtimeConfig.getProcessOutput();
@@ -72,7 +72,14 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 						"----------------------\n" +
 						""+logWatch.getOutput();
 			}
-			throw new IOException("Could not start process: "+failureFound);
+			try {
+				// Process could be finished with success here! In this case no need to throw an exception!
+				if(process.waitFor() != 0){
+					throw new IOException("Could not start process: "+failureFound);
+				}
+			} catch (InterruptedException e) {
+				throw new IOException("Could not start process: "+failureFound, e);
+			}
 		}
 	}
 

--- a/src/main/java/de/flapdoodle/embed/mongo/config/AbstractMongoConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/AbstractMongoConfigBuilder.java
@@ -37,20 +37,38 @@ public abstract class AbstractMongoConfigBuilder<T extends IMongoConfig> extends
 	protected static final TypedProperty<Net> NET = TypedProperty.with("Net", Net.class);
 	protected static final TypedProperty<IMongoCmdOptions> CMD_OPTIONS = TypedProperty.with("CmdOptions", IMongoCmdOptions.class);
 	protected static final TypedProperty<String> PID_FILE = TypedProperty.with("PidFile", String.class);
+	protected static final TypedProperty<String> USERNAME = TypedProperty.with("UserName", String.class);
+	protected static final TypedProperty<String> PASSWORD = TypedProperty.with("Password", String.class);
+	protected static final TypedProperty<String> DBNAME = TypedProperty.with("DbName", String.class);
 
-	
+
 	public AbstractMongoConfigBuilder() throws UnknownHostException, IOException  {
 		timeout().setDefault(new Timeout());
 		net().setDefault(new Net());
 		cmdOptions().setDefault(new MongoCmdOptionsBuilder().build());
+		username().setDefault("");
+		password().setDefault("");
+		dbName().setDefault("");
 	}
-	
+
 	protected IProperty<IFeatureAwareVersion> version() {
 		return property(VERSION);
 	}
 
 	protected IProperty<Timeout> timeout() {
 		return property(TIMEOUT);
+	}
+
+	protected IProperty<String> username() {
+		return property(USERNAME);
+	}
+
+	protected IProperty<String> password() {
+		return property(PASSWORD);
+	}
+
+	protected IProperty<String> dbName() {
+		return property(DBNAME);
 	}
 
 	protected IProperty<Net> net() {
@@ -64,26 +82,32 @@ public abstract class AbstractMongoConfigBuilder<T extends IMongoConfig> extends
 	protected IProperty<String> pidFile() {
 		return property(PID_FILE);
 	}
-	
+
 	static class ImmutableMongoConfig implements IMongoConfig {
 
 		private final ISupportConfig _supportConfig;
-		
+
 		private final IFeatureAwareVersion _version;
 		private final Timeout _timeout;
 		private final Net _net;
 		private final IMongoCmdOptions _cmdOptions;
 		private final String _pidFile;
+		private final String _userName;
+		private final String _password;
 
-		public ImmutableMongoConfig(ISupportConfig supportConfig, IFeatureAwareVersion version, Net net, Timeout timeout,IMongoCmdOptions cmdOptions,String pidFile) {
+		public ImmutableMongoConfig(ISupportConfig supportConfig, IFeatureAwareVersion version, Net net,
+									String userName, String password,
+									Timeout timeout, IMongoCmdOptions cmdOptions, String pidFile) {
 			super();
 			_supportConfig = supportConfig;
-			
+
 			_version = version;
 			_net = net;
 			_timeout = timeout;
 			_cmdOptions = cmdOptions;
 			_pidFile = pidFile;
+			_userName = userName;
+			_password = password;
 		}
 
 		@Override
@@ -105,12 +129,22 @@ public abstract class AbstractMongoConfigBuilder<T extends IMongoConfig> extends
 		public IMongoCmdOptions cmdOptions() {
 			return _cmdOptions;
 		}
-		
+
+		@Override
+		public String password() {
+			return _password;
+		}
+
+		@Override
+		public String userName() {
+			return _userName;
+		}
+
 		@Override
 		public String pidFile() {
 			return _pidFile;
 		}
-		
+
 		@Override
 		public ISupportConfig supportConfig() {
 			return _supportConfig;

--- a/src/main/java/de/flapdoodle/embed/mongo/config/IMongoCmdOptions.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/IMongoCmdOptions.java
@@ -24,7 +24,9 @@ package de.flapdoodle.embed.mongo.config;
 public interface IMongoCmdOptions {
 
 	Integer syncDelay();
-	
+
+	String storageEngine();
+
 	boolean isVerbose();
 
 	boolean useNoPrealloc();
@@ -34,4 +36,8 @@ public interface IMongoCmdOptions {
 	boolean useNoJournal();
 	
 	boolean enableTextSearch();
+
+	boolean auth();
+
+	boolean master();
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/IMongoConfig.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/IMongoConfig.java
@@ -33,6 +33,10 @@ public interface IMongoConfig extends IExecutableProcessConfig {
 	Net net();
 
 	IMongoCmdOptions cmdOptions();
-	
+
+	String password();
+
+	String userName();
+
     String pidFile();
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/IMongoShellConfig.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/IMongoShellConfig.java
@@ -29,4 +29,5 @@ public interface IMongoShellConfig extends IMongoConfig {
 
 	String getScriptName();
 
+	String getDbName();
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/IMongodConfig.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/IMongodConfig.java
@@ -22,6 +22,7 @@ package de.flapdoodle.embed.mongo.config;
 
 import de.flapdoodle.embed.mongo.config.processlistener.IMongoProcessListener;
 
+import java.util.Map;
 
 public interface IMongodConfig extends IMongoConfig {
 
@@ -30,4 +31,6 @@ public interface IMongodConfig extends IMongoConfig {
 	boolean isConfigServer();
 
 	IMongoProcessListener processListener();
+
+	Map params();
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongoCmdOptionsBuilder.java
@@ -27,20 +27,26 @@ import de.flapdoodle.embed.process.builder.TypedProperty;
 public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 
 	protected static final TypedProperty<Integer> SYNC_DELAY = TypedProperty.with("syncDelay", Integer.class);
+	protected static final TypedProperty<String> STORAGE_ENGINE = TypedProperty.with("storageEngine", String.class);
 	protected static final TypedProperty<Boolean> VERBOSE = TypedProperty.with("verbose", Boolean.class);
 	protected static final TypedProperty<Boolean> NOPREALLOC = TypedProperty.with("noprealloc", Boolean.class);
 	protected static final TypedProperty<Boolean> SMALLFILES = TypedProperty.with("smallfiles", Boolean.class);
 	protected static final TypedProperty<Boolean> NOJOURNAL = TypedProperty.with("nojournal", Boolean.class);
 	protected static final TypedProperty<Boolean> ENABLE_TEXTSEARCH = TypedProperty.with("enableTextSearch", Boolean.class);
-	
-	
+	protected static final TypedProperty<Boolean> ENABLE_AUTH = TypedProperty.with("auth", Boolean.class);
+	protected static final TypedProperty<Boolean> MASTER = TypedProperty.with("master", Boolean.class);
+
+
 	public MongoCmdOptionsBuilder() {
 		property(SYNC_DELAY).setDefault(0);
+		property(STORAGE_ENGINE).setDefault(null);
 		property(VERBOSE).setDefault(false);
 		property(NOPREALLOC).setDefault(true);
 		property(SMALLFILES).setDefault(true);
 		property(NOJOURNAL).setDefault(true);
 		property(ENABLE_TEXTSEARCH).setDefault(false);
+		property(ENABLE_AUTH).setDefault(false);
+		property(MASTER).setDefault(false);
 	}
 
 	public MongoCmdOptionsBuilder useNoPrealloc(boolean value) {
@@ -72,7 +78,22 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		set(ENABLE_TEXTSEARCH, verbose);
 		return this;
 	}
-	
+
+	public MongoCmdOptionsBuilder useStorageEngine(String storageEngine) {
+		set(STORAGE_ENGINE, storageEngine);
+		return this;
+	}
+
+	public MongoCmdOptionsBuilder enableAuth(boolean enable) {
+		set(ENABLE_AUTH, enable);
+		return this;
+	}
+
+	public MongoCmdOptionsBuilder master(boolean enable) {
+		set(MASTER, enable);
+		return this;
+	}
+
 	public MongoCmdOptionsBuilder defaultSyncDelay() {
 		set(SYNC_DELAY, null);
 		return this;
@@ -81,12 +102,15 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 	@Override
 	public IMongoCmdOptions build() {
 		Integer syncDelay = get(SYNC_DELAY, null);
+		String storageEngine = get(STORAGE_ENGINE, null);
 		boolean verbose = get(VERBOSE);
 		boolean noPrealloc = get(NOPREALLOC);
 		boolean smallFiles = get(SMALLFILES);
 		boolean noJournal = get(NOJOURNAL);
 		boolean enableTextSearch = get(ENABLE_TEXTSEARCH);
-		return new MongoCmdOptions(syncDelay, verbose, noPrealloc, smallFiles, noJournal, enableTextSearch);
+		boolean auth = get(ENABLE_AUTH);
+		boolean master = get(MASTER);
+		return new MongoCmdOptions(syncDelay, storageEngine, verbose, noPrealloc, smallFiles, noJournal, enableTextSearch, auth, master);
 	}
 
 	static class MongoCmdOptions implements IMongoCmdOptions {
@@ -97,21 +121,31 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		private final boolean _smallFiles;
 		private final boolean _noJournal;
 		private final boolean _enableTextSearch;
+		private final boolean _auth;
+		private final boolean _master;
+		private final String _storageEngine;
 
-
-		public MongoCmdOptions(Integer syncDelay, boolean verbose, boolean noPrealloc, boolean smallFiles,
-		                       boolean noJournal, boolean enableTextSearch) {
+		public MongoCmdOptions(Integer syncDelay, String storageEngine, boolean verbose, boolean noPrealloc, boolean smallFiles,
+                               boolean noJournal, boolean enableTextSearch, boolean auth, boolean master) {
 			_syncDelay = syncDelay;
+			_storageEngine = storageEngine;
 			_verbose = verbose;
 			_noPrealloc = noPrealloc;
 			_smallFiles = smallFiles;
 			_noJournal = noJournal;
 			_enableTextSearch = enableTextSearch;
+			_auth = auth;
+			_master = master;
 		}
 
 		@Override
 		public Integer syncDelay() {
 			return _syncDelay;
+		}
+
+		@Override
+		public String storageEngine() {
+			return _storageEngine;
 		}
 
 		@Override
@@ -137,6 +171,16 @@ public class MongoCmdOptionsBuilder extends AbstractBuilder<IMongoCmdOptions> {
 		@Override
 		public boolean enableTextSearch() {
 			return _enableTextSearch;
+		}
+
+		@Override
+		public boolean auth() {
+			return _auth;
+		}
+
+		@Override
+		public boolean master() {
+			return _master;
 		}
 	}
 }

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongoImportConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongoImportConfigBuilder.java
@@ -111,7 +111,8 @@ public class MongoImportConfigBuilder extends AbstractMongoConfigBuilder<IMongoI
         IMongoCmdOptions cmdOptions=get(CMD_OPTIONS);
         String pidFile = get(PID_FILE);
 
-        return new ImmutableMongoImportConfig(version, net, timeout, cmdOptions, pidFile, database, collection ,importFile,jsonArray, upsert, drop);
+		return new ImmutableMongoImportConfig(version, net, timeout, cmdOptions, pidFile,
+				database, collection, importFile, jsonArray, upsert, drop);
     }
 
     static class ImmutableMongoImportConfig extends ImmutableMongoConfig implements IMongoImportConfig {
@@ -122,8 +123,9 @@ public class MongoImportConfigBuilder extends AbstractMongoConfigBuilder<IMongoI
         private final Boolean _dropCollection;
         private final Boolean _upsetDocuments;
 
-        public ImmutableMongoImportConfig(IFeatureAwareVersion version, Net net, Timeout timeout, IMongoCmdOptions cmdOptions, String pidFile, String database, String collection, String importFile,Boolean jsonArray, Boolean upsert, Boolean drop) {
-            super(new SupportConfig(Command.MongoImport),version, net, timeout,cmdOptions,pidFile);
+		public ImmutableMongoImportConfig(IFeatureAwareVersion version, Net net, Timeout timeout, IMongoCmdOptions cmdOptions, String pidFile,
+											String database, String collection, String importFile, Boolean jsonArray, Boolean upsert, Boolean drop) {
+			super(new SupportConfig(Command.MongoImport), version, net, null, null, timeout, cmdOptions, pidFile);
             _databaseName=database;
             _collectionName=collection;
             _getImportFile=importFile;

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongoShellConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongoShellConfigBuilder.java
@@ -20,6 +20,10 @@
  */
 package de.flapdoodle.embed.mongo.config;
 
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
+import de.flapdoodle.embed.process.builder.TypedProperty;
+
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -50,8 +54,23 @@ public class MongoShellConfigBuilder extends AbstractMongoConfigBuilder<IMongoSh
 		return this;
 	}
 
+	public MongoShellConfigBuilder username(String username) {
+		username().set(username);
+		return this;
+	}
+
+	public MongoShellConfigBuilder password(String password) {
+		password().set(password);
+		return this;
+	}
+
 	public MongoShellConfigBuilder net(Net net) {
 		net().set(net);
+		return this;
+	}
+
+	public MongoShellConfigBuilder dbName(String dbName) {
+		dbName().set(dbName);
 		return this;
 	}
 
@@ -64,11 +83,11 @@ public class MongoShellConfigBuilder extends AbstractMongoConfigBuilder<IMongoSh
 		set(JS_SCRIPT, scriptName);
 		return this;
 	}
-	
+
 	public MongoShellConfigBuilder parameters(String... parameters) {
 		return parameters(Arrays.asList(parameters));
 	}
-	
+
 	public MongoShellConfigBuilder parameters(List<String> parameters) {
 		set(JS_SCRIPT_PARAMETERS, parameters);
 		return this;
@@ -81,23 +100,29 @@ public class MongoShellConfigBuilder extends AbstractMongoConfigBuilder<IMongoSh
 		Timeout timeout = timeout().get();
 		IMongoCmdOptions cmdOptions=get(CMD_OPTIONS);
 		String pidFile = get(PID_FILE);
-		
+
 		String name = get(JS_SCRIPT,null);
 		List<String> parameters = get(JS_SCRIPT_PARAMETERS,new ArrayList<String>());
 		if ((name==null) && (parameters.isEmpty())) {
 			throw new RuntimeException("you must set parameters or scriptName");
 		}
 
-		return new ImmutableMongoShellConfig(version, net, timeout, cmdOptions, pidFile, name, parameters);
+		return new ImmutableMongoShellConfig(version, net, timeout, cmdOptions, pidFile, name,
+					username().get(), password().get(), dbName().get(), parameters);
 	}
 
 	static class ImmutableMongoShellConfig extends ImmutableMongoConfig implements IMongoShellConfig {
 
 		private final String _name;
+		private final String _dbname;
 		private final List<String> _parameters;
 
-		public ImmutableMongoShellConfig(IFeatureAwareVersion version, Net net, Timeout timeout, IMongoCmdOptions cmdOptions, String pidFile, String scriptName, List<String> parameters) {
-			super(new SupportConfig(Command.Mongo), version, net, timeout,cmdOptions,pidFile);
+		public ImmutableMongoShellConfig(IFeatureAwareVersion version, Net net, Timeout timeout,
+											IMongoCmdOptions cmdOptions, String pidFile,
+											String scriptName, String username, String password, String dbName,
+											List<String> parameters) {
+ 			super(new SupportConfig(Command.Mongo), version, net, username, password, timeout, cmdOptions, pidFile);
+ 			this._dbname = dbName;
 			this._name = scriptName;
 			this._parameters = Collections.unmodifiableList(new ArrayList<String>(parameters));
 		}
@@ -110,6 +135,11 @@ public class MongoShellConfigBuilder extends AbstractMongoConfigBuilder<IMongoSh
 		@Override
 		public String getScriptName() {
 			return _name;
+ 		}
+
+ 		@Override
+ 		public String getDbName() {
+ 			return _dbname;
 		}
 
 	}

--- a/src/main/java/de/flapdoodle/embed/mongo/config/MongosConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/MongosConfigBuilder.java
@@ -77,8 +77,9 @@ public class MongosConfigBuilder extends AbstractMongoConfigBuilder<IMongosConfi
 
 		private final String _configDB;
 
-		public ImmutableMongosConfig(IFeatureAwareVersion version, Net net, Timeout timeout, IMongoCmdOptions cmdOptions, String pidFile, String configDB) {
-			super(MongosSupportConfig.getInstance(), version, net, timeout,cmdOptions,pidFile);
+		public ImmutableMongosConfig(IFeatureAwareVersion version, Net net, Timeout timeout, IMongoCmdOptions cmdOptions,
+										String pidFile, String configDB) {
+			super(MongosSupportConfig.getInstance(), version, net, null, null, timeout, cmdOptions, pidFile);
 			_configDB = configDB;
 		}
 

--- a/src/main/java/de/flapdoodle/embed/mongo/distribution/Version.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/distribution/Version.java
@@ -144,9 +144,14 @@ public enum Version implements IFeatureAwareVersion {
   V2_7_1("2.7.1",Feature.SYNC_DELAY),
 
   /**
-   * Latest 2.7 series development release
+   * Latest 3.0 series development release
    */
-  V3_0_0("3.0.0",Feature.SYNC_DELAY),
+  V3_0_0("3.0.0", Feature.SYNC_DELAY),
+  V3_0_1("3.0.1",Feature.SYNC_DELAY),
+  /**
+   * Latest 3.1 series development release
+   */
+  V3_1_0("3.1.0",Feature.SYNC_DELAY),
 
   ;
 
@@ -185,22 +190,24 @@ public enum Version implements IFeatureAwareVersion {
 		@Deprecated
 		V2_3(V2_3_0),
 		V2_4(V2_4_10),
-    @Deprecated
+        @Deprecated
 		V2_5(V2_5_4),
+        @Deprecated
+		V2_6(V2_6_8),
+        @Deprecated
+        V2_7(V2_7_1),
+
 		/**
 		 * Latest production release
 		 */
-		V2_6(V2_6_8),
+		V3_0(V3_0_1),
+		/**
+		 * Latest development release
+		 */
+		V3_1(V3_1_0),
 
-    /**
-     * Latest development release
-     */
-		@Deprecated
-    V2_7(V2_7_1),
-    V3_0(V3_0_0),
-
-		PRODUCTION(V2_6),
-		DEVELOPMENT(V3_0), ;
+		PRODUCTION(V3_0),
+		DEVELOPMENT(V3_1), ;
 
 		private final IFeatureAwareVersion _latest;
 

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoShell.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoShell.java
@@ -29,6 +29,8 @@ import de.flapdoodle.embed.mongo.config.IMongoShellConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 
+import static java.util.Arrays.asList;
+
 /**
  *
  */
@@ -38,7 +40,7 @@ public class MongoShell extends AbstractMongo {
 			throws UnknownHostException {
 		List<String> ret = new ArrayList<String>();
 		ret.addAll(Arrays.asList(files.executable().getAbsolutePath()));
-		
+
 		String hostname="localhost";
 		Net net = config.net();
 		if (net.isIpv6()) {
@@ -48,10 +50,22 @@ public class MongoShell extends AbstractMongo {
 			hostname=net.getBindIp();
 		}
 
-		
+		if (config.password() != null && !config.userName().isEmpty()) {
+			ret.addAll(asList(
+				"--username", config.userName()
+			));
+		}
+		if (config.password() != null && !config.password().isEmpty()) {
+			ret.addAll(asList(
+				"--password", config.password()
+			));
+		}
 
-		
-		ret.add(hostname+":" + net.getPort());
+		if (config.getDbName() != null && !config.getDbName().isEmpty()) {
+			ret.add(hostname + ":" + net.getPort() + "/" + config.getDbName());
+		} else {
+			ret.add(hostname+":" + net.getPort());
+        }
 		if (!config.getScriptParameters().isEmpty()) {
 			ret.add("--eval");
 			StringBuilder eval = new StringBuilder();
@@ -63,7 +77,7 @@ public class MongoShell extends AbstractMongo {
 		if (config.getScriptName()!=null) {
 			ret.add(config.getScriptName());
 		}
-		
+
 		return ret;
 	}
 }


### PR DESCRIPTION
Hi guys. We've incorporated some of our changes into this PR. 
* Actualize versions to current MongoDB releases.
* Add the additional config options for mongo and mongod (authorization, database name, replica set options). 
* Support for the `storageEngine` option.

#115  partly resolves our needs, but not all of them.

P.S. Sry for the different indentation style. We're using default IDEA configuration and auto formatting. It's painful to turn it off.
P.P.S. We cannot use embedded mongo without these options, so we have to use our own fork for now. It would be great if you merge this PR or implement such features in the following releases.