### PR TITLE
Fix process after run hook

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
@@ -51,7 +51,7 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 			throws IOException {
 		super(distribution, config, runtimeConfig, executable);
 	}
-	
+
 	@Override
 	protected final void onAfterProcessStart(ProcessControl process, IRuntimeConfig runtimeConfig) throws IOException {
 		ProcessOutput outputConfig = runtimeConfig.getProcessOutput();
@@ -72,7 +72,14 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 						"----------------------\n" +
 						""+logWatch.getOutput();
 			}
-			throw new IOException("Could not start process: "+failureFound);
+			try {
+				// Process could be finished with success here! In this case no need to throw an exception!
+				if(process.waitFor() != 0){
+					throw new IOException("Could not start process: "+failureFound);
+				}
+			} catch (InterruptedException e) {
+				throw new IOException("Could not start process: "+failureFound, e);
+			}
 		}
 	}
 


### PR DESCRIPTION
After upgrading to mongodb 3 test with import becomes failed. This is because mongoimport process could be already finished successfully (exit code 0) when we're just trying to read its output and checking for success.
I believe this code should be considered for refactoring.