### PR TITLE
Updated the readme to point to a more feature-rich maven plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Embedded MongoDB will provide a platform neutral way for running mongodb in unit
 
 ### Other ways to use Embedded MongoDB
 
-- in a Maven build using [embedmongo-maven-plugin](https://github.com/joelittlejohn/embedmongo-maven-plugin)
+- in a Maven build using [maven-mongodb-plugin](https://github.com/Syncleus/maven-mongodb-plugin)
 - in a Clojure/Leiningen project using [lein-embongo](https://github.com/joelittlejohn/lein-embongo)
 - in a Gradle build using [gradle-mongo-plugin](https://github.com/sourcemuse/GradleMongoPlugin)
 - in a Scala/specs2 specification using [specs2-embedmongo](https://github.com/athieriot/specs2-embedmongo)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Embedded MongoDB will provide a platform neutral way for running mongodb in unit
 
 ### Other ways to use Embedded MongoDB
 
-- in a Maven build using [maven-mongodb-plugin](https://github.com/Syncleus/maven-mongodb-plugin)
+- in a Maven build using [maven-mongodb-plugin](https://github.com/Syncleus/maven-mongodb-plugin) or the older [embedmongo-maven-plugin](https://github.com/joelittlejohn/embedmongo-maven-plugin)
 - in a Clojure/Leiningen project using [lein-embongo](https://github.com/joelittlejohn/lein-embongo)
 - in a Gradle build using [gradle-mongo-plugin](https://github.com/sourcemuse/GradleMongoPlugin)
 - in a Scala/specs2 specification using [specs2-embedmongo](https://github.com/athieriot/specs2-embedmongo)


### PR DESCRIPTION
The current maven plugin being pointed to has a slow development history and does not expose the majority of the flapdoodle configuration options. The new project linked is a fork from that project with significantly more features, it also has more unit tests (more stable) and is in maven central. All good reasons to use the new link instead.