### PR TITLE
Fixes #110

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/MongoImportProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/MongoImportProcess.java
@@ -29,11 +29,12 @@ import de.flapdoodle.embed.mongo.runtime.MongoImport;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
+import de.flapdoodle.embed.process.runtime.AbstractProcess;
 
 /**
  * Created by canyaman on 10/04/14.
  */
-public class MongoImportProcess  extends AbstractMongoProcess<IMongoImportConfig, MongoImportExecutable, MongoImportProcess> {
+public class MongoImportProcess  extends AbstractProcess<IMongoImportConfig, MongoImportExecutable, MongoImportProcess> {
 
     public MongoImportProcess(Distribution distribution, IMongoImportConfig config, IRuntimeConfig runtimeConfig,
                          MongoImportExecutable mongosExecutable) throws IOException {
@@ -45,9 +46,13 @@ public class MongoImportProcess  extends AbstractMongoProcess<IMongoImportConfig
             throws IOException {
         return MongoImport.getCommandLine(getConfig(), files);
     }
+
     @Override
-    protected String successMessage() {
-        return "imported";
+    protected void stopInternal() {
+    }
+
+    @Override
+    protected void cleanupInternal() {
     }
 }
 

--- a/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoImport.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/runtime/MongoImport.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import de.flapdoodle.embed.mongo.config.IMongoImportConfig;
+import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
 
 /**
@@ -41,7 +42,16 @@ public class MongoImport extends AbstractMongo {
         if (config.cmdOptions().isVerbose()) {
             ret.add("-v");
         }
-        applyNet(config.net(),ret);
+        Net net = config.net();
+        ret.add("--port");
+        ret.add("" + net.getPort());
+        if (net.isIpv6()) {
+            ret.add("--ipv6");
+        }
+        if (net.getBindIp()!=null) {
+            ret.add("--host");
+            ret.add(net.getBindIp());
+        }
 
         if (config.getDatabaseName()!=null) {
             ret.add("--db");


### PR DESCRIPTION
`MongoImportProcess` would shut down the Mongod process when it stops, because it extended the `AbstractMongoProcess` and thus had the same cleanup sequence.