### PR TITLE
Cross platfrom solution for getting file path for CLI

### DIFF
--- a/src/test/java/de/flapdoodle/embed/mongo/MongoImportExecutableTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/MongoImportExecutableTest.java
@@ -40,6 +40,7 @@ import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.runtime.Network;
+import java.io.File;
 
 /**
  * Created by canyaman on 10/04/14.
@@ -61,12 +62,8 @@ public class MongoImportExecutableTest  extends TestCase {
         MongodProcess mongod = mongodExe.start();
 
         String jsonFile=Thread.currentThread().getContextClassLoader().getResource("sample.json").toString();
-        if (jsonFile.startsWith("file://")) {
-        	jsonFile=jsonFile.replaceFirst("file:/","");
-        } else {
-            jsonFile=jsonFile.replaceFirst("file:","");
-        }
-
+        jsonFile=jsonFile.replaceFirst("file:","");
+        jsonFile = new File(jsonFile).getAbsolutePath();
         MongoImportExecutable mongoImportExecutable=mongoImportExecutable(serverPort,"importDatabase","importCollection",jsonFile,true,true,true);
         MongoImportProcess mongoImportProcess=null;
         Boolean dataImported=false;


### PR DESCRIPTION
Use java.io.file to resolve the path before using it as a command line parameter. may still fail if the file path contains spaces...