### PR TITLE
Add Maven repository to the Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ notifications:
   email:
     - michael@mosmann.de
     - m.joehren@gmail.com
+
+cache:
+  directories:
+    - $HOME/.m2/repository


### PR DESCRIPTION
This speeds up Travis because dependencies can be cached between builds.