### PR TITLE
Checks environment variable for artifact download location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/src/main/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilder.java
@@ -31,18 +31,18 @@ import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.io.directories.UserHome;
 import de.flapdoodle.embed.process.io.progress.StandardConsoleProgressListener;
 
-import java.util.Map;
+import java.util.Optional;
 
 public class DownloadConfigBuilder extends de.flapdoodle.embed.process.config.store.DownloadConfigBuilder {
 
-	private Map<String, String> environmentVariables;
+	private Optional<String> artifactDownloadLocationEnvironmentVariable;
 
 	public DownloadConfigBuilder() {
-		this(System.getenv());
+		this(Optional.ofNullable(System.getenv().get("EMBEDDED_MONGO_ARTIFACTS")));
 	}
 	
-	protected DownloadConfigBuilder(Map<String, String> environmentVariables) {
-		this.environmentVariables = environmentVariables;
+	protected DownloadConfigBuilder(Optional<String> artifactDownloadLocationEnvironmentVariable) {
+		this.artifactDownloadLocationEnvironmentVariable = artifactDownloadLocationEnvironmentVariable;
 	}
 
 	public DownloadConfigBuilder packageResolverForCommand(Command command) {
@@ -65,12 +65,11 @@ public class DownloadConfigBuilder extends de.flapdoodle.embed.process.config.st
 	}
 
 	private IDirectory defaultArtifactDownloadLocation() {
-		String artifactDownloadLocationEnvironmentVariable = environmentVariables.get("EMBEDDED_MONGO_ARTIFACTS");
-		if (artifactDownloadLocationEnvironmentVariable == null) {
-			return new UserHome(".embedmongo");
+		if (artifactDownloadLocationEnvironmentVariable.isPresent()) {
+			return new FixedPath(artifactDownloadLocationEnvironmentVariable.get());
 		}
 		else {
-			return new FixedPath(artifactDownloadLocationEnvironmentVariable);
+			return new UserHome(".embedmongo");
 		}
 	}
 

--- a/src/main/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilder.java
@@ -26,10 +26,24 @@ import de.flapdoodle.embed.process.config.store.IDownloadPath;
 import de.flapdoodle.embed.process.distribution.Distribution;
 import de.flapdoodle.embed.process.distribution.Platform;
 import de.flapdoodle.embed.process.extract.UUIDTempNaming;
+import de.flapdoodle.embed.process.io.directories.FixedPath;
+import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.io.directories.UserHome;
 import de.flapdoodle.embed.process.io.progress.StandardConsoleProgressListener;
 
+import java.util.Map;
+
 public class DownloadConfigBuilder extends de.flapdoodle.embed.process.config.store.DownloadConfigBuilder {
+
+	private Map<String, String> environmentVariables;
+
+	public DownloadConfigBuilder() {
+		this(System.getenv());
+	}
+	
+	protected DownloadConfigBuilder(Map<String, String> environmentVariables) {
+		this.environmentVariables = environmentVariables;
+	}
 
 	public DownloadConfigBuilder packageResolverForCommand(Command command) {
 		packageResolver(new Paths(command));
@@ -44,10 +58,20 @@ public class DownloadConfigBuilder extends de.flapdoodle.embed.process.config.st
 		fileNaming().setDefault(new UUIDTempNaming());
 		downloadPath().setDefault(new PlattformDependendDownloadPath());
 		progressListener().setDefault(new StandardConsoleProgressListener());
-		artifactStorePath().setDefault(new UserHome(".embedmongo"));
+		artifactStorePath().setDefault(defaultArtifactDownloadLocation());
 		downloadPrefix().setDefault(new DownloadPrefix("embedmongo-download"));
 		userAgent().setDefault(new UserAgent("Mozilla/5.0 (compatible; Embedded MongoDB; +https://github.com/flapdoodle-oss/embedmongo.flapdoodle.de)"));
 		return this;
+	}
+
+	private IDirectory defaultArtifactDownloadLocation() {
+		String artifactDownloadLocationEnvironmentVariable = environmentVariables.get("EMBEDDED_MONGO_ARTIFACTS");
+		if (artifactDownloadLocationEnvironmentVariable == null) {
+			return new UserHome(".embedmongo");
+		}
+		else {
+			return new FixedPath(artifactDownloadLocationEnvironmentVariable);
+		}
 	}
 
 	private static class PlattformDependendDownloadPath implements IDownloadPath {

--- a/src/test/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilderTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilderTest.java
@@ -18,14 +18,14 @@ public class DownloadConfigBuilderTest extends DownloadConfigBuilder {
 	public static Collection<Object[]> data() {
 		String defaultArtifactDownloadLocation = new UserHome(".embedmongo").asFile().getAbsolutePath();
 		return Arrays.asList(new Object[][] {
-				{ "Use home directory when environment variable not present", noEnvironmentVariable(), defaultArtifactDownloadLocation},
-				{ "Environment variable overrides default when supplied", environmentVariableSetTo("/some/explicit/directory"), "/some/explicit/directory" },
-				{ "Environment variable overrides default when supplied", environmentVariableSetTo("/another/explicit/directory"), "/another/explicit/directory" },
+				{ "Use home directory when environment variable not present", defaultArtifactDownloadLocation, Optional.empty()},
+				{ "Environment variable overrides default when supplied", "/some/explicit/directory", Optional.of("/some/explicit/directory") },
+				{ "Environment variable overrides default when supplied", "/another/explicit/directory", Optional.of("/another/explicit/directory") },
 		});
 	}
 
-	public DownloadConfigBuilderTest(String description, Map<String, String> environment, String expectedDirectory) {
-		super(environment);
+	public DownloadConfigBuilderTest(String description, String expectedDirectory, Optional<String> artifactDownloadLocationEnvironmentVariable) {
+		super(artifactDownloadLocationEnvironmentVariable);
 		this.description = description;
 		this.expectedDirectory = expectedDirectory;
 	}
@@ -34,12 +34,5 @@ public class DownloadConfigBuilderTest extends DownloadConfigBuilder {
 	public void artifactStorePathChosenProperly() {
 		defaults();
 		Assert.assertEquals(description, expectedDirectory, this.artifactStorePath().get().asFile().getAbsolutePath());
-	}
-
-	private static ImmutableMap<Object, Object> noEnvironmentVariable() {
-		return ImmutableMap.of();
-	}
-	private static ImmutableMap<String, String> environmentVariableSetTo(String v1) {
-		return ImmutableMap.of("EMBEDDED_MONGO_ARTIFACTS", v1);
 	}
 }

--- a/src/test/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilderTest.java
+++ b/src/test/java/de/flapdoodle/embed/mongo/config/DownloadConfigBuilderTest.java
@@ -1,0 +1,45 @@
+package de.flapdoodle.embed.mongo.config;
+
+import com.google.common.collect.ImmutableMap;
+import de.flapdoodle.embed.process.io.directories.UserHome;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+@RunWith(Parameterized.class)
+public class DownloadConfigBuilderTest extends DownloadConfigBuilder {
+	private final String description;
+	private final String expectedDirectory;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		String defaultArtifactDownloadLocation = new UserHome(".embedmongo").asFile().getAbsolutePath();
+		return Arrays.asList(new Object[][] {
+				{ "Use home directory when environment variable not present", noEnvironmentVariable(), defaultArtifactDownloadLocation},
+				{ "Environment variable overrides default when supplied", environmentVariableSetTo("/some/explicit/directory"), "/some/explicit/directory" },
+				{ "Environment variable overrides default when supplied", environmentVariableSetTo("/another/explicit/directory"), "/another/explicit/directory" },
+		});
+	}
+
+	public DownloadConfigBuilderTest(String description, Map<String, String> environment, String expectedDirectory) {
+		super(environment);
+		this.description = description;
+		this.expectedDirectory = expectedDirectory;
+	}
+
+	@Test
+	public void artifactStorePathChosenProperly() {
+		defaults();
+		Assert.assertEquals(description, expectedDirectory, this.artifactStorePath().get().asFile().getAbsolutePath());
+	}
+
+	private static ImmutableMap<Object, Object> noEnvironmentVariable() {
+		return ImmutableMap.of();
+	}
+	private static ImmutableMap<String, String> environmentVariableSetTo(String v1) {
+		return ImmutableMap.of("EMBEDDED_MONGO_ARTIFACTS", v1);
+	}
+}


### PR DESCRIPTION
As per #177, this change checks the `EMBEDDED_MONGO_ARTIFACTS` environment variable when picking the default location to store downloaded artifacts. This allows the location to be controlled at an environmental level rather than an application level, making it possible to manage usage of a shared continuous integration environment more centrally.