### PR TITLE
Clean tmp files, when stopProcess times out

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/AbstractMongoProcess.java
@@ -113,8 +113,11 @@ public abstract class AbstractMongoProcess<T extends IMongoConfig, E extends Exe
 						}
 					}
 				}
-
-				stopProcess();
+				try {
+					stopProcess();
+				} catch (IllegalStateException ise) {
+					// This exception is already logged in stopProcess
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In case stopProcess takes more than 3 seconds,
the process is destroyed and an Exception is thrown.

cleanupInternal is not called when this exception is thrown,
causing stale files to fill up tmp directory.

The fix is to not propagate this particular exception.

  #212