### PR TITLE
fix archive type for osx tools package

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/packageresolver/OSXPackageFinder.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/packageresolver/OSXPackageFinder.java
@@ -124,7 +124,7 @@ public class OSXPackageFinder implements PackageFinder, HasPlatformMatchRules {
               )))
           .finder(UrlTemplatePackageResolver.builder()
               .fileSet(fileSet)
-              .archiveType(archiveType)
+              .archiveType(ArchiveType.ZIP)
               .urlTemplate("/tools/db/mongodb-database-tools-macos-x86_64-{tools.version}.zip")
               .build())
           .build();


### PR DESCRIPTION
This fixes the following error for Version.Main.V4_4 and Version.Main.V5_0 on OSX:

```
de.flapdoodle.embed.process.exceptions.DistributionException: java.io.IOException: File /Users/trautmane/.embedmongo/tools/db/mongodb-database-tools-macos-x86_64-100.5.1.zip

        at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:71)
        at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:52)
        ...
Caused by: java.io.IOException: File /Users/trautmane/.embedmongo/tools/db/mongodb-database-tools-macos-x86_64-100.5.1.zip
        at de.flapdoodle.embed.process.extract.AbstractExtractor.archiveStreamWithExceptionHint(AbstractExtractor.java:52)
        at de.flapdoodle.embed.process.extract.AbstractExtractor.extract(AbstractExtractor.java:65)
        at de.flapdoodle.embed.process.store.ArtifactStore.extractFileSet(ArtifactStore.java:86)
        at de.flapdoodle.embed.process.store.ExtractedArtifactStore.extractFileSet(ExtractedArtifactStore.java:101)
        at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:59)
        ... 31 more
Caused by: java.io.IOException: Input is not in the .gz format
        at org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream.init(GzipCompressorInputStream.java:193)
        at org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream.<init>(GzipCompressorInputStream.java:167)
        at org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream.<init>(GzipCompressorInputStream.java:131)
        at de.flapdoodle.embed.process.extract.TgzExtractor.archiveStream(TgzExtractor.java:42)
        at de.flapdoodle.embed.process.extract.AbstractExtractor.archiveStreamWithExceptionHint(AbstractExtractor.java:46)
        ... 35 more
```