### PR TITLE
fix(args): allow argument key without value

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/commands/MongodArguments.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/commands/MongodArguments.java
@@ -135,7 +135,12 @@ public abstract class MongodArguments {
 		builder.add(/*executable.toAbsolutePath().toString(),*/ "--dbpath", dbDirectory.toAbsolutePath().toString());
 
 		config.params().forEach((key, val) -> builder.add("--setParameter", format("%s=%s", key, val)));
-		config.args().forEach(builder::add);
+		config.args().forEach((key, val) -> {
+			builder.add(key);
+			if (!val.isEmpty()) {
+				builder.add(val);
+			}
+		});
 
 		if (config.auth()) {
 			LOGGER.info(


### PR DESCRIPTION
Hello 👋

Previously in version `3`, `MongodConfig` allowed *args* **without value** (ex: `--notablescan`).
https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/blob/de.flapdoodle.embed.mongo-3.4.11/src/main/java/de/flapdoodle/embed/mongo/runtime/Mongod.java#L177

But now we cannot: `MongodArguments` add an **empty `String`** in command line arguments, then the process fails.