### PR TITLE
Instruct user to set EMBEDDED_MONGO_ARTIFACTS for overriding artifact location

### DIFF
--- a/src/test/resources/de/flapdoodle/embed/mongo/doc/Howto.md
+++ b/src/test/resources/de/flapdoodle/embed/mongo/doc/Howto.md
@@ -63,3 +63,8 @@ ${importJsonIntoMongoDB}
 ```java
 ${setupUserAndRoles}
 ```
+
+### Override artifact download path
+
+By default, artifacts are stored in `.embedmongo` in the user's home directory.
+Override this behavior by setting the `EMBEDDED_MONGO_ARTIFACTS` environment variable.


### PR DESCRIPTION
It took me a while to find this, resulting in reading a lot of code. Let's add it to the docs.

Closes #535 