### PR TITLE
Correct link for Spring 3.x documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,5 +175,4 @@ If you have any trouble in using them feel free to create an issue.
 - [Spring 2.5.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-2.5.x)
 - [Spring 2.6.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-2.6.x)
 - [Spring 2.7.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-2.7.x)
-- [Spring 3.0.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-3.0.x)
-- [Spring 3.1.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-3.1.x)
+- [Spring 3.x.x](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/tree/spring-3.x.x)


### PR DESCRIPTION
Looks like both 3.0.x and 3.1.x have been merged into the single 3.x.x.